### PR TITLE
Add support for signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added changelog
+- Improve batch job and restart behavior (#30)
+- Add support for signals (#31)
 
 ## [0.6.0] - 2020-02-17


### PR DESCRIPTION
This allows running `nomad alloc signal` on the command line and
should also allow consul-template and vault stanzas to deliver
a signal in case the credentials/values they manage changed.