### PR TITLE
Fix container stop and destroy procedure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fix pot-stop and pot-destroy command invocations (#49)
+
 ## [0.9.1] - 2023-09-29
 ### Added
 - Add optional keyword "attributes" to set pot attributes like `devfs_ruleset` on the task (#42)

--- a/driver/handle.go
+++ b/driver/handle.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -15,6 +16,8 @@ type taskHandle struct {
 	syexec syexec
 	pid    int
 	logger hclog.Logger
+
+	calledDestroy atomic.Bool
 
 	// stateLock syncs access to all fields below
 	stateLock sync.RWMutex

--- a/driver/prepare.go
+++ b/driver/prepare.go
@@ -163,10 +163,6 @@ func prepareContainer(cfg *drivers.TaskConfig, taskCfg TaskConfig) (syexec, erro
 	argvStart = append(argvStart, "start", potName)
 	se.argvStart = argvStart
 
-	argvStop := make([]string, 0, 50)
-	argvStop = append(argvStop, "stop", potName)
-	se.argvStop = argvStop
-
 	argvStats := make([]string, 0, 50)
 	argvStats = append(argvStats, "get-rss", "-p", potName, "-J")
 	se.argvStats = argvStats
@@ -229,27 +225,6 @@ func (s *syexec) Close() {
 	}
 }
 
-func prepareStop(cfg *drivers.TaskConfig, taskCfg TaskConfig) syexec {
-	argv := make([]string, 0, 50)
-	var se syexec
-	se.taskConfig = taskCfg
-	se.cfg = cfg
-	se.env = cfg.EnvList()
-
-	// action can be run/exec
-
-	argv = append(argv, "stop")
-
-	parts := strings.Split(cfg.ID, "/")
-	completeName := parts[1] + "_" + parts[2] + "_" + parts[0]
-
-	argv = append(argv, completeName)
-
-	se.argvStop = append(argv, taskCfg.Args...)
-
-	return se
-}
-
 func prepareDestroy(cfg *drivers.TaskConfig, taskCfg TaskConfig) syexec {
 	argv := make([]string, 0, 50)
 	var se syexec
@@ -264,9 +239,7 @@ func prepareDestroy(cfg *drivers.TaskConfig, taskCfg TaskConfig) syexec {
 	parts := strings.Split(cfg.ID, "/")
 	completeName := parts[1] + "_" + parts[2] + "_" + parts[0]
 
-	argv = append(argv, "-p", completeName)
-
-	se.argvDestroy = append(argv, taskCfg.Args...)
+	se.argvDestroy = append(argv, "-p", completeName)
 
 	return se
 


### PR DESCRIPTION
These commands erroneously appended taskCfg.Args to both commands,
resulting in various undesirable outcomes, depending on the value
if taskCfg.Args. One obvious problem is, that the appended "-F"
to pot-destroy never came into effect. Args starting with "-" could
also make the commands do different things or fail completely.

While investigating, I found that there are more things wrong with
this (partially due to how pot handles things).

As a result, this change removes using the stop command and
instead relies on calling destroy -F. Destroying the container
is done exactly one (enforced using an atomic counter), so
double-destroy, which happened in the past and messed up
things, should not happen anymore.

While there, bump plugin version.